### PR TITLE
Create new property to control target clickable

### DIFF
--- a/app/src/main/java/com/takusemba/spotlightsample/CustomOverlayPositionFragment.kt
+++ b/app/src/main/java/com/takusemba/spotlightsample/CustomOverlayPositionFragment.kt
@@ -23,6 +23,9 @@ class CustomOverlayPositionFragment : Fragment(R.layout.fragment_fragment_sample
     view.findViewById<View>(R.id.start).setOnClickListener { startButton ->
       val targets = ArrayList<Target>()
 
+      view.findViewById<TextView>(R.id.one).setOnClickListener {
+        Toast.makeText(requireContext(),"Target One Clicked",Toast.LENGTH_SHORT).show()
+      }
       // first target
       val firstRoot = FrameLayout(requireContext())
 
@@ -30,7 +33,7 @@ class CustomOverlayPositionFragment : Fragment(R.layout.fragment_fragment_sample
       val anchor1 = view.findViewById<View>(R.id.one)
       val firstTarget = Target.Builder()
           .setAnchor(anchor1)
-          .setShape(RoundedRectangle(1.5f*anchor1.height.toFloat(), 2*anchor1.width.toFloat(), 15f))
+          .setShape(RoundedRectangle(1.5f*anchor1.height.toFloat(), 2*anchor1.width.toFloat(), 15f,clickable = true))
           .setOverlay(first)
           .setOverlayAlignment(OverlayAlignment.TOP_LEFT)
           .setVerticalMargin(16f)

--- a/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.kt
@@ -84,7 +84,7 @@ internal class SpotlightView @JvmOverloads constructor(
 
             if (x.toFloat() in leftX..rightX &&
                 y.toFloat() in topY..bottomY) {
-              return false
+              return target?.shape?.clickable != true
             }
           }
         }
@@ -101,7 +101,7 @@ internal class SpotlightView @JvmOverloads constructor(
             val bottom = it.y + halfHeight
 
             if (x.toFloat() in left..right && y.toFloat() in top..bottom) {
-              return false
+              return target?.shape?.clickable != true
             }
           }
         }

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.kt
@@ -16,7 +16,8 @@ class Circle @JvmOverloads constructor(
     override val duration: Long = DEFAULT_DURATION,
     override val interpolator: TimeInterpolator = DEFAULT_INTERPOLATOR,
     override val width: Float = 2*radius,
-    override val height: Float = 2*radius
+    override val height: Float = 2*radius,
+    override var clickable: Boolean = true
 ) : Shape {
 
   override fun draw(canvas: Canvas, point: PointF, value: Float, paint: Paint) {

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
@@ -17,7 +17,8 @@ class RoundedRectangle @JvmOverloads constructor(
     private val radius: Float,
     override val type :Shape.ShapeType = Shape.ShapeType.ROUNDED_RECTANGLE,
     override val duration: Long = DEFAULT_DURATION,
-    override val interpolator: TimeInterpolator = DEFAULT_INTERPOLATOR
+    override val interpolator: TimeInterpolator = DEFAULT_INTERPOLATOR,
+    override var clickable: Boolean = true
 ) : Shape {
 
   override fun draw(canvas: Canvas, point: PointF, value: Float, paint: Paint) {

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/Shape.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/Shape.kt
@@ -33,6 +33,7 @@ interface Shape {
 
   val height: Float
 
+  var clickable:Boolean
   /**
    * Draws the Shape.
    *


### PR DESCRIPTION
Create one property to control spotlighted target clickability.

**To Test**
- You can change clickable property in `app/src/main/java/com/takusemba/spotlightsample/CustomOverlayPositionFragment.kt` at line `36`
- Try to click Number `1` in spotlighted target
- Change clickable to false will not show the Toas when Number `1` is clicked